### PR TITLE
config: Change DB location

### DIFF
--- a/lib/request_info/config.rb
+++ b/lib/request_info/config.rb
@@ -28,7 +28,8 @@ module RequestInfo
     # Path to the GeoIPCity .dat file
     def geoip_path
       @@geoip_path ||=
-        '/usr/share/GeoIP/GeoIP2-City.mmdb'
+        ENV['GEOIPDBPATH'] ||
+        '/usr/local/GeoIP/GeoIP2-City.mmdb'
     end
 
     def geoip_path=(path)


### PR DESCRIPTION
New environment variable "GEOIPDBPATH" to allow change of GeoIP DB location and the new default location is set to /usr/local/GeoIP folder.