### PR TITLE
Rename geoipdb_path setting, and make its configuration cleaner

### DIFF
--- a/lib/request_info/configuration.rb
+++ b/lib/request_info/configuration.rb
@@ -11,7 +11,7 @@ module RequestInfo
     def set_defaults
       self.locale_name_map_path = default_locale_name_map_path
       self.locale_map_path = default_locale_map_path
-      self.geoipdb_path = default_geoipdb_path
+      self.geoipdb_path = nil
     end
 
     def default_locale_name_map_path
@@ -20,10 +20,6 @@ module RequestInfo
 
     def default_locale_map_path
       File.expand_path("data/country_locale_map.csv", gem_root)
-    end
-
-    def default_geoipdb_path
-      "/usr/local/GeoIP/GeoIP2-City.mmdb"
     end
 
     def gem_root

--- a/lib/request_info/configuration.rb
+++ b/lib/request_info/configuration.rb
@@ -23,7 +23,7 @@ module RequestInfo
     end
 
     def default_geoipdb_path
-      ENV["GEOIPDBPATH"] || "/usr/local/GeoIP/GeoIP2-City.mmdb"
+      "/usr/local/GeoIP/GeoIP2-City.mmdb"
     end
 
     def gem_root

--- a/lib/request_info/configuration.rb
+++ b/lib/request_info/configuration.rb
@@ -1,6 +1,6 @@
 module RequestInfo
   class Configuration
-    attr_accessor :locale_name_map_path, :locale_map_path, :geoip_path
+    attr_accessor :locale_name_map_path, :locale_map_path, :geoipdb_path
 
     def initialize
       set_defaults
@@ -11,7 +11,7 @@ module RequestInfo
     def set_defaults
       self.locale_name_map_path = default_locale_name_map_path
       self.locale_map_path = default_locale_map_path
-      self.geoip_path = default_geoip_path
+      self.geoipdb_path = default_geoipdb_path
     end
 
     def default_locale_name_map_path
@@ -22,7 +22,7 @@ module RequestInfo
       File.expand_path("data/country_locale_map.csv", gem_root)
     end
 
-    def default_geoip_path
+    def default_geoipdb_path
       ENV["GEOIPDBPATH"] || "/usr/local/GeoIP/GeoIP2-City.mmdb"
     end
 

--- a/lib/request_info/geoip.rb
+++ b/lib/request_info/geoip.rb
@@ -19,7 +19,7 @@ module RequestInfo::GeoIP
       self.database = MaxmindGeoIP2
 
       MaxmindGeoIP2.file(
-        RequestInfo.configuration.geoip_path,
+        RequestInfo.configuration.geoipdb_path,
       )
       MaxmindGeoIP2.locale("en")
 
@@ -30,7 +30,7 @@ module RequestInfo::GeoIP
     rescue
       Rails.logger.warn (
         "[request_info] Warning: Unable to initialize GeoIP database: " +
-        "'#{RequestInfo.config.geoip_path}'. " +
+        "'#{RequestInfo.config.geoipdb_path}'. " +
         "Check configuration."
       )
     end

--- a/lib/request_info/railtie.rb
+++ b/lib/request_info/railtie.rb
@@ -13,7 +13,7 @@ module RequestInfo
     end
 
     # Setup GeoIP database after initialization since initializers may modify
-    # geoip_path
+    # geoipdb_path
     config.after_initialize do
       GeoIP.setup
     end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe RequestInfo::Configuration do
   it { is_expected.to respond_to(:locale_name_map_path=) }
   it { is_expected.to respond_to(:locale_map_path) }
   it { is_expected.to respond_to(:locale_map_path=) }
-  it { is_expected.to respond_to(:geoip_path) }
-  it { is_expected.to respond_to(:geoip_path=) }
+  it { is_expected.to respond_to(:geoipdb_path) }
+  it { is_expected.to respond_to(:geoipdb_path=) }
 
   describe "defaults" do
     example do
@@ -20,7 +20,7 @@ RSpec.describe RequestInfo::Configuration do
     end
 
     example do
-      val = subject.geoip_path
+      val = subject.geoipdb_path
       expect(val).to point_to_existing_file & end_with(".mmdb")
     end
   end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe RequestInfo::Configuration do
 
     example do
       val = subject.geoipdb_path
-      expect(val).to point_to_existing_file & end_with(".mmdb")
+      expect(val).to be(nil)
     end
   end
 end

--- a/spec/request_info_spec.rb
+++ b/spec/request_info_spec.rb
@@ -6,6 +6,18 @@ RSpec.describe RequestInfo do
   end
 
   describe "gem configuration" do
+    # Stub the RequestInfo module, and clear its class variables.
+    # As a consequence these tests:
+    # - do not affect other ones
+    # - are not affected by suite-wide gem configuration
+    before do
+      class_duplicate = RequestInfo.dup
+      class_duplicate.instance_variables.each do |ivar|
+        class_duplicate.remove_instance_variable(ivar)
+      end
+      stub_const "RequestInfo", class_duplicate
+    end
+
     example "when ::configure has not been called, ::configuration returns " +
       "an immutable frozen Configuration instance with default settings" do
 

--- a/spec/request_info_spec.rb
+++ b/spec/request_info_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe RequestInfo do
 
       retval = RequestInfo.configuration
       expect(retval).to be_a(RequestInfo::Configuration) & be_frozen
-      %i[locale_name_map_path locale_map_path geoip_path].each do |attr_name|
+      %i[locale_name_map_path locale_map_path geoipdb_path].each do |attr_name|
         attr_val = retval.send(attr_name)
         attr_default = RequestInfo::Configuration.new.send(attr_name)
         expect(attr_val).to eq(attr_default)
@@ -24,24 +24,24 @@ RSpec.describe RequestInfo do
 
       RequestInfo.configure do |c|
         expect(c).to be_a(RequestInfo::Configuration)
-        c.geoip_path = "some/path"
-        expect(c.geoip_path).to eq("some/path")
+        c.geoipdb_path = "some/path"
+        expect(c.geoipdb_path).to eq("some/path")
       end
       current_conf = RequestInfo.configuration
       expect(current_conf).to be_a(RequestInfo::Configuration) & be_frozen
-      expect(current_conf.geoip_path).to eq("some/path")
+      expect(current_conf.geoipdb_path).to eq("some/path")
     end
 
     example "::configure may be called multiple times" do
-      RequestInfo.configure { |c| c.geoip_path = "some/path" }
+      RequestInfo.configure { |c| c.geoipdb_path = "some/path" }
       RequestInfo.configure { |c| c.locale_map_path = "different/path" }
-      expect(RequestInfo.configuration.geoip_path).to eq("some/path")
+      expect(RequestInfo.configuration.geoipdb_path).to eq("some/path")
       expect(RequestInfo.configuration.locale_map_path).to eq("different/path")
-      RequestInfo.configure { |c| c.geoip_path = "yet/another/path" }
-      expect(RequestInfo.configuration.geoip_path).to eq("yet/another/path")
+      RequestInfo.configure { |c| c.geoipdb_path = "yet/another/path" }
+      expect(RequestInfo.configuration.geoipdb_path).to eq("yet/another/path")
       expect(RequestInfo.configuration.locale_map_path).to eq("different/path")
       RequestInfo.configure { |c| c.locale_map_path = "final/path" }
-      expect(RequestInfo.configuration.geoip_path).to eq("yet/another/path")
+      expect(RequestInfo.configuration.geoipdb_path).to eq("yet/another/path")
       expect(RequestInfo.configuration.locale_map_path).to eq("final/path")
     end
 
@@ -50,10 +50,10 @@ RSpec.describe RequestInfo do
         Thread.new do
           path = "some/path/#{i}"
           RequestInfo.configure do |c|
-            c.geoip_path = path
+            c.geoipdb_path = path
             sleep(0.01)
           end
-          expect(RequestInfo.configuration.geoip_path).to eq(path)
+          expect(RequestInfo.configuration.geoipdb_path).to eq(path)
         end
       end
 
@@ -62,7 +62,7 @@ RSpec.describe RequestInfo do
 
     example "::configure returns nil" do
       # Prevent unwanted access to mutable configuration
-      expect(RequestInfo.configure { |c| c.geoip_path = "path" }).to be(nil)
+      expect(RequestInfo.configure { |c| c.geoipdb_path = "path" }).to be(nil)
     end
   end
 end

--- a/spec/support/geolite.rb
+++ b/spec/support/geolite.rb
@@ -1,2 +1,2 @@
-ENV["GEOIPDBPATH"] ||=
-  File.expand_path("../../../geolitedb/GeoLite2-City.mmdb", __FILE__)
+dbpath = File.expand_path("../../../geolitedb/GeoLite2-City.mmdb", __FILE__)
+RequestInfo.configure { |config| config.geoipdb_path = dbpath }


### PR DESCRIPTION
- Rename setting from `geoip_path` to `geoipdb_path`
- Change its default value to `nil`
- Remove support for `GEOIPDBPATH` environment variable
- Improve configuration tests after failures