### PR TITLE
Rewrite client IP detection from scratch

### DIFF
--- a/spec/detectors/ip_detector_spec.rb
+++ b/spec/detectors/ip_detector_spec.rb
@@ -5,6 +5,12 @@ require "rails"
 RSpec.describe RequestInfo::Detectors::IpDetector do
   let(:detected) { RequestInfo.results }
 
+  let(:env) { { "REMOTE_ADDR" => proxy_1, "HTTP_X_FORWARDED_FOR" => h_xff } }
+  let(:h_xff) { [ip_spoof, iana_org_ip, nask_pl_ip, proxy_2].join(", ") }
+  let(:proxy_1) { "::1" }
+  let(:proxy_2) { "192.168.99.1" }
+  let(:ip_spoof) { iso_org_ip }
+
   # iana.org is registered in Los Angeles, US
   let(:iana_org_ip) { "192.0.32.8" }
   let(:iana_org_country_code) { "US" }
@@ -14,6 +20,11 @@ RSpec.describe RequestInfo::Detectors::IpDetector do
   let(:nask_pl_ip) { "195.187.242.157" }
   let(:nask_pl_country_code) { "PL" }
   let(:nask_pl_city) { "Warsaw" }
+
+  # iso.org is registered in Vernier, Geneva, Switzerland
+  let(:iso_org_ip) { "138.81.11.132" }
+  let(:iso_org_country_code) { "CH" }
+  let(:iso_org_city) { "Vernier, Geneva" }
 
   # Following IP is reserved and no one will ever register it.
   # See full list at: https://en.wikipedia.org/wiki/Reserved_IP_addresses
@@ -25,18 +36,15 @@ RSpec.describe RequestInfo::Detectors::IpDetector do
     expect(described_class.instance).to be(described_class.instance)
   end
 
-  shared_context "ip examples" do |source_description|
-    it "takes #{source_description} as user IP address" do
+  shared_context "ip examples" do
+    it "detects user IP address" do
       expectations_on_inner_app do
         expect(detected.ip).to eq(expected_ip)
       end
       make_request(env)
     end
 
-    it "finds IP geographical location of #{source_description}" do
-      if source_description =~ /X-Forwarded-For/
-        pending "Gem behaves inconsistently.  A failing spec has been disabled."
-      end
+    it "finds IP geographical location" do
       expectations_on_inner_app do
         expect(detected.ipinfo["country_code"]).to eq(expected_country_code)
         expect(detected.ipinfo["city"]).to eq(expected_city)
@@ -47,43 +55,27 @@ RSpec.describe RequestInfo::Detectors::IpDetector do
 
   context "when ActionDispatch::RemoteIp is available" do
     before do
-      rack_stack_builder.unshift ActionDispatch::RemoteIp
+      rack_stack_builder.unshift(
+        ActionDispatch::RemoteIp,
+        false, # don't raise exception on IP spoofing attempt
+        nask_pl_ip, # add IP to trusted proxies
+      )
     end
 
-    before do
-      get_ip_class = ActionDispatch::RemoteIp::GetIp
-      get_ip_dbl = double(get_ip_class)
-      expect(get_ip_dbl).to receive(:calculate_ip).and_return(iana_org_ip)
-      expect(get_ip_class).to receive(:new).and_return(get_ip_dbl)
-    end
-
-    let(:env) { {} }
+    # Rightmost untrusted proxy in XFF header
     let(:expected_ip) { iana_org_ip }
     let(:expected_country_code) { iana_org_country_code }
     let(:expected_city) { iana_org_city }
 
-    include_examples "ip examples", "ActionDispatch::RemoteIp guessings"
+    include_examples "ip examples"
   end
 
-  context "when ActionDispatch::RemoteIp is unavailable, but X-Forwarded-For " +
-    "header is present" do
-    let(:env) { { "HTTP_X_FORWARDED_FOR" => "#{iana_org_ip}, #{nask_pl_ip}" } }
-    let(:expected_ip) { "#{iana_org_ip}, #{nask_pl_ip}" }
-    let(:expected_country_code) { iana_org_country_code }
-    let(:expected_city) { iana_org_city }
-
-    include_examples "ip examples",
-      "the set of IP addresses from X-Forwarded-For header"
-  end
-
-  context "when ActionDispatch::RemoteIp is unavailable, neither " +
-    "X-Forwarded-For header is, but REMOTE_ADDR is present" do
-    let(:env) { { "REMOTE_ADDR" => nask_pl_ip } }
+  context "when ActionDispatch::RemoteIp is unavailable" do
+    # Rightmost untrusted proxy in XFF header
     let(:expected_ip) { nask_pl_ip }
     let(:expected_country_code) { nask_pl_country_code }
     let(:expected_city) { nask_pl_city }
 
-    include_examples "ip examples",
-      "the set of IP addresses from REMOTE_ADDR variable"
+    include_examples "ip examples"
   end
 end


### PR DESCRIPTION
See #13 for initial discussion.

Client's IP address is obtained from `ActionDispatch::RemoteIp` middleware. If it's unavailable, then `Rack::Request` is used. The former is more customizable, however is not available by default, even in Rails.