### PR TITLE
Fix inconsistent behaviour

### DIFF
--- a/lib/request_info/detectors/locale_detector.rb
+++ b/lib/request_info/detectors/locale_detector.rb
@@ -27,7 +27,6 @@ module RequestInfo
         #
         # Note 2: we clear off this modification in after_app
         locale = unless compat.empty?
-                   env["request_info.locale.detected"] =
                      ::I18n.locale =
                        compat.first.first
                  else

--- a/lib/request_info/detectors/locale_detector.rb
+++ b/lib/request_info/detectors/locale_detector.rb
@@ -26,13 +26,10 @@ module RequestInfo
         # of the first.
         #
         # Note 2: we clear off this modification in after_app
-        locale = unless compat.empty?
-                       compat.first.first
-                 else
-                   # If we are not compatible with any detected locales, use
-                   # default locale.
-                   ::I18n.default_locale.to_s
-        end
+
+        # If we are not compatible with any detected locales, use
+        # default locale.
+        locale = compat.empty? ? ::I18n.default_locale.to_s : compat.first.first
 
         ::I18n.locale = locale
 

--- a/lib/request_info/detectors/locale_detector.rb
+++ b/lib/request_info/detectors/locale_detector.rb
@@ -27,13 +27,14 @@ module RequestInfo
         #
         # Note 2: we clear off this modification in after_app
         locale = unless compat.empty?
-                     ::I18n.locale =
                        compat.first.first
                  else
                    # If we are not compatible with any detected locales, use
                    # default locale.
                    ::I18n.default_locale.to_s
         end
+
+        ::I18n.locale = locale
 
         {
           locale: locale,

--- a/spec/detectors/locale_detector_spec.rb
+++ b/spec/detectors/locale_detector_spec.rb
@@ -39,16 +39,6 @@ RSpec.describe RequestInfo::Detectors::LocaleDetector do
       make_request(env)
     end
 
-    it "sets locale to #{locale_description} in env hash" do
-      if locale_description == "default one"
-        pending "Gem behaves inconsistently.  A failing spec has been disabled."
-      end
-      expectations_on_inner_app do |inner_app_env|
-        expect(inner_app_env[env_key_name]).to eq(expected_locale.to_s)
-      end
-      make_request(env)
-    end
-
     it "sets locale to #{locale_description} inside the inner app" do
       expectations_on_inner_app do
         expect(I18n.locale.to_s).to eq(expected_locale.to_s)


### PR DESCRIPTION
Stop setting the odd `env["request_info.locale.detected"]` which was a source of inconsistencies.