### PR TITLE
Stop returning any meaningful values from detecting methods

### DIFF
--- a/lib/request_info/detectors/ip_detector.rb
+++ b/lib/request_info/detectors/ip_detector.rb
@@ -13,8 +13,6 @@ module RequestInfo
 
         results.ip = ip
         results.ipinfo = RequestInfo::GeoIP.instance.lookup(ip)
-
-        results
       end
 
       private

--- a/lib/request_info/detectors/locale_detector.rb
+++ b/lib/request_info/detectors/locale_detector.rb
@@ -33,7 +33,6 @@ module RequestInfo
         locale = compat.empty? ? ::I18n.default_locale.to_s : compat.first.first
 
         results.locale = locale
-        results
       end
 
       def wrap_app

--- a/lib/request_info/detectors/timezone_detector.rb
+++ b/lib/request_info/detectors/timezone_detector.rb
@@ -9,7 +9,7 @@ module RequestInfo
 
         results = RequestInfo.results
         tzinfo_id, tzinfo = get_tzinfo_from_ipinfo(results.ipinfo)
-        return nil unless tzinfo_id && tzinfo
+        return unless tzinfo_id && tzinfo
 
         results.timezone = tzinfo
         results.timezone_id = tzinfo_id

--- a/lib/request_info/detectors/timezone_detector.rb
+++ b/lib/request_info/detectors/timezone_detector.rb
@@ -15,8 +15,6 @@ module RequestInfo
         results.timezone_id = tzinfo_id
         results.timezone_offset = calculate_utc_offset(tzinfo)
         results.timezone_desc = tz_description(tzinfo)
-
-        results
       end
 
       private


### PR DESCRIPTION
A `RequestInfo::Results` is always accessed by using thread variables.  Return values are totally meaningless in this context. They shouldn't be specified to avoid the impression that they do matter.