### PR TITLE
Make GeoIP2 configuration optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ matrix:
       gemfile: "gemfiles/Rails-4.1.gemfile"
     - rvm: "2.5"
       gemfile: "gemfiles/Rails-head.gemfile"
+    - rvm: "2.5"
+      env: DISABLE_GEOIP2=1
 
   allow_failures:
     - rvm: "ruby-head"

--- a/gemfiles/Rails-4.1.gemfile
+++ b/gemfiles/Rails-4.1.gemfile
@@ -2,3 +2,4 @@
 eval File.read "gemfiles/common.gemfile"
 
 gem "rails", "~> 4.1.0"
+gem "maxmind_geoip2"

--- a/gemfiles/Rails-4.2.gemfile
+++ b/gemfiles/Rails-4.2.gemfile
@@ -2,3 +2,4 @@
 eval File.read "gemfiles/common.gemfile"
 
 gem "rails", "~> 4.2.0"
+gem "maxmind_geoip2"

--- a/gemfiles/Rails-5.0.gemfile
+++ b/gemfiles/Rails-5.0.gemfile
@@ -2,3 +2,4 @@
 eval File.read "gemfiles/common.gemfile"
 
 gem "rails", "~> 5.0.0"
+gem "maxmind_geoip2"

--- a/gemfiles/Rails-5.1.gemfile
+++ b/gemfiles/Rails-5.1.gemfile
@@ -2,3 +2,4 @@
 eval File.read "gemfiles/common.gemfile"
 
 gem "rails", "~> 5.1.0"
+gem "maxmind_geoip2"

--- a/gemfiles/Rails-head.gemfile
+++ b/gemfiles/Rails-head.gemfile
@@ -2,3 +2,4 @@
 eval File.read "gemfiles/common.gemfile"
 
 gem "rails", github: "rails/rails"
+gem "maxmind_geoip2"

--- a/lib/request_info/configuration.rb
+++ b/lib/request_info/configuration.rb
@@ -3,7 +3,7 @@
 
 module RequestInfo
   class Configuration
-    attr_accessor :locale_name_map_path, :locale_map_path, :geoipdb_path
+    attr_accessor :locale_name_map_path, :locale_map_path, :geoip2_db_path
 
     def initialize
       set_defaults
@@ -14,7 +14,7 @@ module RequestInfo
     def set_defaults
       self.locale_name_map_path = default_locale_name_map_path
       self.locale_map_path = default_locale_map_path
-      self.geoipdb_path = nil
+      self.geoip2_db_path = nil
     end
 
     def default_locale_name_map_path

--- a/lib/request_info/geoip.rb
+++ b/lib/request_info/geoip.rb
@@ -24,11 +24,8 @@ module RequestInfo
     end
 
     def setup_database
-      MaxmindGeoIP2.file(
-        geoip2_db_path,
-      )
+      MaxmindGeoIP2.file(geoip2_db_path)
       MaxmindGeoIP2.locale("en")
-
       MaxmindGeoIP2
     end
 

--- a/lib/request_info/geoip.rb
+++ b/lib/request_info/geoip.rb
@@ -19,6 +19,7 @@ module RequestInfo
     # Sets up the GeoIPCity database for upcoming queries
     def initialize
       unless geoip2_db_path.nil?
+        ensure_maxmind_geoip2_availability
         self.database = setup_database
       end
     end
@@ -38,6 +39,13 @@ module RequestInfo
 
     def geoip2_db_path
       RequestInfo.configuration.geoip2_db_path
+    end
+
+    def ensure_maxmind_geoip2_availability
+      MaxmindGeoIP2
+    rescue LoadError
+      raise "RequestInfo requires maxmind_geoip2 gem for GeoIP2 database " +
+        "lookup. Refer to README for configuration details."
     end
   end
 end

--- a/lib/request_info/geoip.rb
+++ b/lib/request_info/geoip.rb
@@ -23,7 +23,7 @@ module RequestInfo
       self.database = MaxmindGeoIP2
 
       MaxmindGeoIP2.file(
-        RequestInfo.configuration.geoipdb_path,
+        RequestInfo.configuration.geoip2_db_path,
       )
       MaxmindGeoIP2.locale("en")
 
@@ -34,7 +34,7 @@ module RequestInfo
     rescue
       Rails.logger.warn (
         "[request_info] Warning: Unable to initialize GeoIP database: " +
-        "'#{RequestInfo.config.geoipdb_path}'. " +
+        "'#{RequestInfo.config.geoip2_db_path}'. " +
         "Check configuration."
       )
     end

--- a/lib/request_info/geoip.rb
+++ b/lib/request_info/geoip.rb
@@ -34,7 +34,7 @@ module RequestInfo
     rescue
       Rails.logger.warn (
         "[request_info] Warning: Unable to initialize GeoIP database: " +
-        "'#{RequestInfo.config.geoip2_db_path}'. " +
+        "'#{RequestInfo.configuration.geoip2_db_path}'. " +
         "Check configuration."
       )
     end

--- a/lib/request_info/geoip.rb
+++ b/lib/request_info/geoip.rb
@@ -39,8 +39,7 @@ module RequestInfo
     # Information currently comes from GeoIPCity.
     #
     def lookup(ip)
-      # Quit if database or IP not present
-      return nil unless self.database && ip && !ip.blank?
+      return nil if self.database.nil? || ip.blank?
       self.database.locate(ip)
     end
 

--- a/lib/request_info/geoip.rb
+++ b/lib/request_info/geoip.rb
@@ -24,14 +24,10 @@ module RequestInfo
     end
 
     def setup_database
-      print "[request_info] setting up geoip database... "
-
       MaxmindGeoIP2.file(
         geoip2_db_path,
       )
       MaxmindGeoIP2.locale("en")
-
-      puts "Done."
 
       MaxmindGeoIP2
     end
@@ -48,8 +44,6 @@ module RequestInfo
     def lookup(ip)
       # Quit if database or IP not present
       return nil unless self.database && ip && !ip.blank?
-
-      # Rails.logger.warn "[request_info] locate results #{self.database.locate(ip).inspect}"
       self.database.locate(ip)
     end
 

--- a/lib/request_info/geoip.rb
+++ b/lib/request_info/geoip.rb
@@ -18,9 +18,13 @@ module RequestInfo
 
     # Sets up the GeoIPCity database for upcoming queries
     def initialize
-      print "[request_info] setting up geoip database... "
+      unless geoip2_db_path.nil?
+        self.database = setup_database
+      end
+    end
 
-      self.database = MaxmindGeoIP2
+    def setup_database
+      print "[request_info] setting up geoip database... "
 
       MaxmindGeoIP2.file(
         geoip2_db_path,
@@ -28,6 +32,8 @@ module RequestInfo
       MaxmindGeoIP2.locale("en")
 
       puts "Done."
+
+      MaxmindGeoIP2
     rescue LoadError
       Rails.logger.warn "[request_info] Warning: " +
         "Gem maxmind_geoip2 not found (>=0.0.8)"

--- a/lib/request_info/geoip.rb
+++ b/lib/request_info/geoip.rb
@@ -23,7 +23,7 @@ module RequestInfo
       self.database = MaxmindGeoIP2
 
       MaxmindGeoIP2.file(
-        RequestInfo.configuration.geoip2_db_path,
+        geoip2_db_path,
       )
       MaxmindGeoIP2.locale("en")
 
@@ -34,7 +34,7 @@ module RequestInfo
     rescue
       Rails.logger.warn (
         "[request_info] Warning: Unable to initialize GeoIP database: " +
-        "'#{RequestInfo.configuration.geoip2_db_path}'. " +
+        "'#{geoip2_db_path}'. " +
         "Check configuration."
       )
     end
@@ -54,6 +54,10 @@ module RequestInfo
 
       # Rails.logger.warn "[request_info] locate results #{self.database.locate(ip).inspect}"
       self.database.locate(ip)
+    end
+
+    def geoip2_db_path
+      RequestInfo.configuration.geoip2_db_path
     end
   end
 end

--- a/lib/request_info/geoip.rb
+++ b/lib/request_info/geoip.rb
@@ -34,15 +34,6 @@ module RequestInfo
       puts "Done."
 
       MaxmindGeoIP2
-    rescue LoadError
-      Rails.logger.warn "[request_info] Warning: " +
-        "Gem maxmind_geoip2 not found (>=0.0.8)"
-    rescue
-      Rails.logger.warn (
-        "[request_info] Warning: Unable to initialize GeoIP database: " +
-        "'#{geoip2_db_path}'. " +
-        "Check configuration."
-      )
     end
 
     ## FOR TESTING

--- a/lib/request_info/geoip.rb
+++ b/lib/request_info/geoip.rb
@@ -4,13 +4,13 @@
 require "maxmind_geoip2"
 require "singleton"
 
-# Our interface to GeoIP.
-#
-# Provides 2 module functions:
-#   setup
-#   lookup(ip)
-#
 module RequestInfo
+  # Brigdes MaxmindGeoIP2.
+  #
+  # Examples:
+  # RequestInfo::GeoIP.instance.lookup('116.49.226.82')
+  # RequestInfo::GeoIP.instance.lookup('24.24.24.24')
+
   class GeoIP
     include Singleton
 
@@ -29,15 +29,8 @@ module RequestInfo
       MaxmindGeoIP2
     end
 
-    ## FOR TESTING
-    ## geoinfo = GeoIp.lookup('116.49.226.82')
-    ## geoinfo = GeoIp.lookup('24.24.24.24')
-
     # Looks up the specified IP address (string) and returns information about
     # the IP address.
-    #
-    # Information currently comes from GeoIPCity.
-    #
     def lookup(ip)
       return nil if self.database.nil? || ip.blank?
       self.database.locate(ip)

--- a/lib/request_info/railtie.rb
+++ b/lib/request_info/railtie.rb
@@ -16,7 +16,7 @@ module RequestInfo
     end
 
     # Preload databases after initialization since initializers may modify
-    # geoipdb_path
+    # geoip2_db_path
     config.after_initialize do
       RequestInfo.preload
     end

--- a/request_info.gemspec
+++ b/request_info.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency("browser")
   spec.add_dependency("i18n")
-  spec.add_dependency("maxmind_geoip2")
   spec.add_dependency("rails", ">= 4.1")
   spec.add_dependency("tzinfo")
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe RequestInfo::Configuration do
   it { is_expected.to respond_to(:locale_name_map_path=) }
   it { is_expected.to respond_to(:locale_map_path) }
   it { is_expected.to respond_to(:locale_map_path=) }
-  it { is_expected.to respond_to(:geoipdb_path) }
-  it { is_expected.to respond_to(:geoipdb_path=) }
+  it { is_expected.to respond_to(:geoip2_db_path) }
+  it { is_expected.to respond_to(:geoip2_db_path=) }
 
   describe "defaults" do
     example do
@@ -23,7 +23,7 @@ RSpec.describe RequestInfo::Configuration do
     end
 
     example do
-      val = subject.geoipdb_path
+      val = subject.geoip2_db_path
       expect(val).to be(nil)
     end
   end

--- a/spec/detectors/ip_detector_spec.rb
+++ b/spec/detectors/ip_detector_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe RequestInfo::Detectors::IpDetector do
     end
 
     it "finds IP geographical location" do
+      skip "GeoIP2 has been purposely disabled" if ENV["DISABLE_GEOIP2"]
       expectations_on_inner_app do
         expect(detected.ipinfo["country_code"]).to eq(expected_country_code)
         expect(detected.ipinfo["city"]).to eq(expected_city)

--- a/spec/request_info_spec.rb
+++ b/spec/request_info_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe RequestInfo do
 
       retval = RequestInfo.configuration
       expect(retval).to be_a(RequestInfo::Configuration) & be_frozen
-      %i[locale_name_map_path locale_map_path geoipdb_path].each do |attr_name|
+      %i[locale_name_map_path locale_map_path geoip2_db_path].each do |attr_name|
         attr_val = retval.send(attr_name)
         attr_default = RequestInfo::Configuration.new.send(attr_name)
         expect(attr_val).to eq(attr_default)
@@ -39,24 +39,24 @@ RSpec.describe RequestInfo do
 
       RequestInfo.configure do |c|
         expect(c).to be_a(RequestInfo::Configuration)
-        c.geoipdb_path = "some/path"
-        expect(c.geoipdb_path).to eq("some/path")
+        c.geoip2_db_path = "some/path"
+        expect(c.geoip2_db_path).to eq("some/path")
       end
       current_conf = RequestInfo.configuration
       expect(current_conf).to be_a(RequestInfo::Configuration) & be_frozen
-      expect(current_conf.geoipdb_path).to eq("some/path")
+      expect(current_conf.geoip2_db_path).to eq("some/path")
     end
 
     example "::configure may be called multiple times" do
-      RequestInfo.configure { |c| c.geoipdb_path = "some/path" }
+      RequestInfo.configure { |c| c.geoip2_db_path = "some/path" }
       RequestInfo.configure { |c| c.locale_map_path = "different/path" }
-      expect(RequestInfo.configuration.geoipdb_path).to eq("some/path")
+      expect(RequestInfo.configuration.geoip2_db_path).to eq("some/path")
       expect(RequestInfo.configuration.locale_map_path).to eq("different/path")
-      RequestInfo.configure { |c| c.geoipdb_path = "yet/another/path" }
-      expect(RequestInfo.configuration.geoipdb_path).to eq("yet/another/path")
+      RequestInfo.configure { |c| c.geoip2_db_path = "yet/another/path" }
+      expect(RequestInfo.configuration.geoip2_db_path).to eq("yet/another/path")
       expect(RequestInfo.configuration.locale_map_path).to eq("different/path")
       RequestInfo.configure { |c| c.locale_map_path = "final/path" }
-      expect(RequestInfo.configuration.geoipdb_path).to eq("yet/another/path")
+      expect(RequestInfo.configuration.geoip2_db_path).to eq("yet/another/path")
       expect(RequestInfo.configuration.locale_map_path).to eq("final/path")
     end
 
@@ -65,10 +65,10 @@ RSpec.describe RequestInfo do
         Thread.new do
           path = "some/path/#{i}"
           RequestInfo.configure do |c|
-            c.geoipdb_path = path
+            c.geoip2_db_path = path
             sleep(0.01)
           end
-          expect(RequestInfo.configuration.geoipdb_path).to eq(path)
+          expect(RequestInfo.configuration.geoip2_db_path).to eq(path)
         end
       end
 
@@ -77,7 +77,7 @@ RSpec.describe RequestInfo do
 
     example "::configure returns nil" do
       # Prevent unwanted access to mutable configuration
-      expect(RequestInfo.configure { |c| c.geoipdb_path = "path" }).to be(nil)
+      expect(RequestInfo.configure { |c| c.geoip2_db_path = "path" }).to be(nil)
     end
   end
 

--- a/spec/support/geolite.rb
+++ b/spec/support/geolite.rb
@@ -1,5 +1,7 @@
 # (c) Copyright 2017 Ribose Inc.
 #
 
-dbpath = File.expand_path("../../../geolitedb/GeoLite2-City.mmdb", __FILE__)
-RequestInfo.configure { |config| config.geoip2_db_path = dbpath }
+unless ENV.fetch("DISABLE_GEOIP2", false)
+  dbpath = File.expand_path("../../../geolitedb/GeoLite2-City.mmdb", __FILE__)
+  RequestInfo.configure { |config| config.geoip2_db_path = dbpath }
+end

--- a/spec/support/geolite.rb
+++ b/spec/support/geolite.rb
@@ -2,4 +2,4 @@
 #
 
 dbpath = File.expand_path("../../../geolitedb/GeoLite2-City.mmdb", __FILE__)
-RequestInfo.configure { |config| config.geoipdb_path = dbpath }
+RequestInfo.configure { |config| config.geoip2_db_path = dbpath }


### PR DESCRIPTION
Make `maxmind_geoip2` an optional dependency. Configuration is now a lot simpler.