### PR TITLE
Relax development dependencies

### DIFF
--- a/request_info.gemspec
+++ b/request_info.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("rails", ">= 4.1")
   spec.add_dependency("tzinfo")
 
-  spec.add_development_dependency "bundler", "~> 1.13"
+  spec.add_development_dependency "bundler", ">= 1.13"
   spec.add_development_dependency "pry", "~> 0.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/request_info.gemspec
+++ b/request_info.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", ">= 1.13"
   spec.add_development_dependency "pry", "~> 0.11"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", ">= 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "timecop", "~> 0.8"
 end


### PR DESCRIPTION
Allow Bundler 2.0 and newer versions of Rake.