### PR TITLE
Fix builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ cache:
 before_install:
   - gem install bundler -v 1.16.1
 
+install:
+  - bundle _1.16.1_ install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}
+
 rvm:
   - "2.2"
   - "2.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,10 @@ cache:
   - bundler
 
 before_install:
-  - gem install bundler -v 1.16.1
+  - gem install bundler -v 1.17.3
 
 install:
-  - bundle _1.16.1_ install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}
+  - bundle _1.17.3_ install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}
 
 rvm:
   - "2.2"


### PR DESCRIPTION
Travis CI was attempting to use recently released Bundler 2, which is incompatible with Rails < 5. This led to build failures.