### PR TITLE
Use #eval_gemfile in gemfiles

### DIFF
--- a/gemfiles/Rails-4.1.gemfile
+++ b/gemfiles/Rails-4.1.gemfile
@@ -1,4 +1,4 @@
-eval File.read "gemfiles/common.gemfile" # rubocop:disable Security/Eval
+eval_gemfile "common.gemfile"
 
 gem "rails", "~> 4.1.0"
 gem "maxmind_geoip2"

--- a/gemfiles/Rails-4.2.gemfile
+++ b/gemfiles/Rails-4.2.gemfile
@@ -1,4 +1,4 @@
-eval File.read "gemfiles/common.gemfile" # rubocop:disable Security/Eval
+eval_gemfile "common.gemfile"
 
 gem "rails", "~> 4.2.0"
 gem "maxmind_geoip2"

--- a/gemfiles/Rails-5.0.gemfile
+++ b/gemfiles/Rails-5.0.gemfile
@@ -1,4 +1,4 @@
-eval File.read "gemfiles/common.gemfile" # rubocop:disable Security/Eval
+eval_gemfile "common.gemfile"
 
 gem "rails", "~> 5.0.0"
 gem "maxmind_geoip2"

--- a/gemfiles/Rails-5.1.gemfile
+++ b/gemfiles/Rails-5.1.gemfile
@@ -1,4 +1,4 @@
-eval File.read "gemfiles/common.gemfile" # rubocop:disable Security/Eval
+eval_gemfile "common.gemfile"
 
 gem "rails", "~> 5.1.0"
 gem "maxmind_geoip2"

--- a/gemfiles/Rails-5.2.gemfile
+++ b/gemfiles/Rails-5.2.gemfile
@@ -1,4 +1,4 @@
-eval File.read "gemfiles/common.gemfile" # rubocop:disable Security/Eval
+eval_gemfile "common.gemfile"
 
 gem "rails", "~> 5.2.0"
 gem "maxmind_geoip2"

--- a/gemfiles/Rails-head.gemfile
+++ b/gemfiles/Rails-head.gemfile
@@ -1,4 +1,4 @@
-eval File.read "gemfiles/common.gemfile" # rubocop:disable Security/Eval
+eval_gemfile "common.gemfile"
 
 gem "rails", github: "rails/rails"
 gem "maxmind_geoip2"


### PR DESCRIPTION
Replace evil `Kernel#eval` with `#eval_gemfile` from Bundler's DSL.